### PR TITLE
Fix unrequested codecompletion menu: When asking for auto-completion,…

### DIFF
--- a/PythonCodeCompletion/PythonCodeCompletion.h
+++ b/PythonCodeCompletion/PythonCodeCompletion.h
@@ -154,7 +154,10 @@ class PythonCodeCompletion : public cbCodeCompletionPlugin
         wxImageList* m_pImageList; //Type icons displayed in the code completion popup
         CCCallTip m_ActiveCalltipDef; //contains the call tip definition retrieved from the server
         wxArrayString m_comp_results; //contains an array of completion results retrieved from the server
-
+        struct {
+            int line;
+            int column;
+        } m_comp_position;
         DECLARE_EVENT_TABLE();
 };
 


### PR DESCRIPTION
… a background task starts, and then the insertion-point changes by the user (probably he doesn't want to wait for the CC results), the codecompletion menu still apeared at a (possibly) undesired location. Should fix Issue#5
(Fix is similar on how Clang CC fixes the exact same issue)